### PR TITLE
Add option to exclude inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ parameter_meta {
 the rest and assign them the `required` category regardless of the
 category assigned in the parameter_meta section.
 
+### Excluding inputs
+Inputs can be excluded by noting them in the `meta` section of a 
+workflow or task. Inside the meta section a list named `exclude` should
+be added inside a `WDL_AID` object. They have to be noted relative 
+to the workflow or task the meta section is defined in.
+For example:
+```wdl
+meta {
+    WDL_AID: {
+        exclude: ["workflow_input", "some_call.task_input"]
+    }
+}
+``` 
+
 ## The default template
 The default template will render a markdown file only describing the
 inputs. You will likely want to write a template with some additional

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ The following variables are made available to the template:
   - `type`: The WDL value type of the input (eg. `String?` or 
     `Pair[Int, Boolean]`)
   - `default`: The default value of the input. If an input has no
-    default, then `None`. ***Note that these currently won't render
-    correctly, with the next release of MiniWDL this should be fixed.***
+    default, then `None`.
   - `description`: The description of the input as specified in the
     parameter_meta sections in the WDL file(s).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-miniwdl
+miniwdl>=0.4.0
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(name="WDL-AID",
       packages=["wdl_aid"],
       package_dir={'': 'src'},
       install_requires=[
-        "miniwdl",
+        "miniwdl>=0.4.0",
         "jinja2"
       ],
       entry_points={

--- a/src/wdl_aid/wdl_aid.py
+++ b/src/wdl_aid/wdl_aid.py
@@ -89,7 +89,7 @@ DEFAULT_TEMPLATE = dedent("""
 
 
 def fully_qualified_inputs(inputs: List[Union[WDL.Env.Binding,
-                                              WDL.Env.Namespace]],
+                                              WDL.Env.Bindings]],
                            namespace: str) -> (str, WDL.Decl):
     """
     :param inputs: A list of Bindings from a Namespace.
@@ -99,11 +99,11 @@ def fully_qualified_inputs(inputs: List[Union[WDL.Env.Binding,
     """
     out = []
     for inp in inputs:
-        if isinstance(inp, WDL.Env.Namespace):
-            out.extend(fully_qualified_inputs(inp.bindings, "{}.{}".format(
-                namespace, inp.namespace)))
-        else:
-            out.append(("{}.{}".format(namespace, inp.name), inp))
+        # if isinstance(inp, WDL.Env.Namespace):
+        #     out.extend(fully_qualified_inputs(inp.bindings, "{}.{}".format(
+        #         namespace, inp.namespace)))
+        # else:
+        out.append(("{}.{}".format(namespace, inp.name), inp))
     return out
 
 
@@ -270,24 +270,19 @@ def main():
                     else get_category(parameter_meta, name,
                                       args.category_key,
                                       args.fallback_category))
+        entry = {
+            "name": name,
+            "type": inp.value.type,
+            "default": str(inp.value.expr),
+            "description":
+                get_description(parameter_meta, name, args.description_key,
+                                args.fallback_description,
+                                args.fallback_description_to_object)
+            }
         try:
-            values[category].append({
-                "name": name, "type": inp.rhs.type,
-                "default": str(inp.rhs.expr),
-                "description":
-                    get_description(parameter_meta, name, args.description_key,
-                                    args.fallback_description,
-                                    args.fallback_description_to_object)
-            })
+            values[category].append(entry)
         except KeyError:
-            values[category] = [{
-                "name": name, "type": inp.rhs.type,
-                "default": str(inp.rhs.expr),
-                "description":
-                    get_description(parameter_meta, name, args.description_key,
-                                    args.fallback_description,
-                                    args.fallback_description_to_object)
-            }]
+            values[category] = [entry]
 
     template = Template(args.template.read_text()
                         if args.template is not None

--- a/src/wdl_aid/wdl_aid.py
+++ b/src/wdl_aid/wdl_aid.py
@@ -21,7 +21,7 @@
 import argparse
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 import WDL
 from jinja2 import Template
@@ -88,8 +88,7 @@ DEFAULT_TEMPLATE = dedent("""
     """)
 
 
-def fully_qualified_inputs(inputs: List[Union[WDL.Env.Binding,
-                                              WDL.Env.Bindings]],
+def fully_qualified_inputs(inputs: WDL.Env.Bindings,
                            namespace: str) -> (str, WDL.Decl):
     """
     :param inputs: A list of Bindings from a Namespace.
@@ -99,10 +98,6 @@ def fully_qualified_inputs(inputs: List[Union[WDL.Env.Binding,
     """
     out = []
     for inp in inputs:
-        # if isinstance(inp, WDL.Env.Namespace):
-        #     out.extend(fully_qualified_inputs(inp.bindings, "{}.{}".format(
-        #         namespace, inp.namespace)))
-        # else:
         out.append(("{}.{}".format(namespace, inp.name), inp))
     return out
 

--- a/src/wdl_aid/wdl_aid.py
+++ b/src/wdl_aid/wdl_aid.py
@@ -21,7 +21,7 @@
 import argparse
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 import WDL
 from jinja2 import Template
@@ -122,7 +122,7 @@ def gather_parameter_meta(node: Union[WDL.Workflow, WDL.Conditional,
                           ) -> Dict[str, Any]:
     """
     :param node: A node from a workflow.
-    :param namespace: The nodes fully qualified namespace name.
+    :param namespace: The node's fully qualified namespace name.
     :return: A dictionary with all the parameter meta values, using
     fully qualified namespaces as keys.
     """
@@ -144,6 +144,60 @@ def gather_parameter_meta(node: Union[WDL.Workflow, WDL.Conditional,
         else:
             if hasattr(el, "body"):  # if or scatter
                 out.update(gather_parameter_meta(el, namespace))
+    return out
+
+
+def process_meta(meta: Dict[str, Any], namespace: str):
+    """
+    :param meta: The meta object to be processed.
+    :param namespace: The namespace to be added to the inputs mentioned
+    exclude.
+    :return: A new dictionary with the exclude key.
+    TODO Maybe add author info and the like.
+    """
+    out = {"exclude": []}
+    try:
+        wdl_aid_meta = meta.get("WDL_AID")
+        for inp in wdl_aid_meta.get("exclude", []):
+            out["exclude"].append("{}.{}".format(namespace, inp))
+        return out
+    except AttributeError:
+        return out
+
+
+def merge_dict_of_lists(old: Dict[str, List[Any]], new: Dict[str, List[Any]]):
+    for key in new:
+        try:
+            old[key].append(new[key])
+        except KeyError:
+            old[key] = new[key]
+    return old
+
+
+def gather_meta(node: Union[WDL.Workflow, WDL.Conditional,
+                            WDL.Scatter], namespace: str,) -> Dict[str, Any]:
+    """
+    :param node: A node from a workflow.
+    :param namespace: The node's fully qualified namespace name.
+    :return: A dictionary with the WDL_AID recognized meta values:
+        - "exclude": A list of inputs to be excluded.
+    """
+    out = {}
+    if hasattr(node, "meta"):
+        merge_dict_of_lists(out, process_meta(node.meta, namespace))
+    for el in node.body:
+        if hasattr(el, "callee"):  # Calls
+            if hasattr(el.callee, "body"):  # sub-workflow
+                merge_dict_of_lists(out, gather_meta(el.callee,
+                                                     "{}.{}".format(namespace,
+                                                                    el.name)))
+            else:  # Tasks
+                merge_dict_of_lists(out, process_meta(el.callee.meta,
+                                                      "{}.{}".format(namespace,
+                                                                     el.name)))
+        else:
+            if hasattr(el, "body"):  # if or scatter
+                merge_dict_of_lists(out, gather_meta(el, namespace))
     return out
 
 
@@ -256,10 +310,13 @@ def main():
                            for required_input in required_inputs]
 
     parameter_meta = gather_parameter_meta(wf, wf.name)
+    meta = gather_meta(wf, wf.name)
 
     values = {"workflow_name": wf.name, "wdl_aid_version": __version__}
 
     for name, inp in inputs:
+        if name in meta["exclude"]:
+            continue
         category = ("required"
                     if name in required_inputs
                     else get_category(parameter_meta, name,

--- a/tests/files/imported.wdl
+++ b/tests/files/imported.wdl
@@ -10,6 +10,7 @@ task echo {
     input {
         String? taskOptional
         String? missingDescription
+        String? shouldBeExcluded
     }
     command {
         echo ~{taskOptional} :p

--- a/tests/files/workflow.wdl
+++ b/tests/files/workflow.wdl
@@ -21,4 +21,9 @@ workflow test {
         input1: "The first input"
         input2: "The second input"
     }
+    meta {
+        WDL_AID: {
+            exclude: ["echo.shouldBeExcluded"]
+        }
+    }
 }

--- a/tests/test_wdl_aid.py
+++ b/tests/test_wdl_aid.py
@@ -34,6 +34,7 @@ def test_fully_qualified_inputs():
     qualified_names = wa.fully_qualified_inputs(available_inputs,
                                                 doc.workflow.name)
     assert [x[0] for x in qualified_names] == ['test.sw.workflowOptional',
+                                               'test.echo.shouldBeExcluded',
                                                'test.echo.missingDescription',
                                                'test.echo.taskOptional',
                                                'test.input2',


### PR DESCRIPTION
This adds an option to exclude inputs. Currently, you would have to assign an input a category which is not supported by the used template in order to hide it. This can only be done in the parameter_meta section of the task or workflow which defines the input. However, one would likely want to exclude inputs on higher levels, eg. when an (optional) input of a sub-workflow should not be overwritten.

I added this option to the meta section because the runtime section is not supported by workflows (and it isn't really relevant to running the task).

This also includes some fixes related to miniwdl's 0.4 release.